### PR TITLE
Fix a docstring in the Q2 test code

### DIFF
--- a/deicode/q2/tests/test_method.py
+++ b/deicode/q2/tests/test_method.py
@@ -58,10 +58,7 @@ class Test_qiime2_rpca(unittest.TestCase):
                                             create_test_table())
 
     def test_qiime2_rpca(self):
-        """Tests that the Q2 and standalone RPCA results match.
-
-           Also validates against ground truth "expected" results.
-        """
+        """Tests that the Q2 and standalone RPCA results match."""
 
         tstdir = "test_output"
         # Run DEICODE through QIIME 2 (specifically, the Artifact API)


### PR DESCRIPTION
This is, like, the most minor pull request ever—so feel free to treat it with low priority :)

TLDR: when I was working on this test, I ended up commenting out the ground-truth checking code (due to the randomness of the test inputs), but I forgot to remove the part of the docstring that said the test checked against ground truths. Figured it'd be good to correct the docstring accordingly (so that it doesn't mislead anyone going through the code in the future).