### PR TITLE
Produce robust clr matrix as output.

### DIFF
--- a/deicode/rpca.py
+++ b/deicode/rpca.py
@@ -70,6 +70,7 @@ def rpca(table: biom.Table,
     p = p[:n_components]
     s = s[:n_components]
     # save the loadings
+    robust_clr = pd.DataFrame(X, index=table.index, columns=table.columns)
     feature_loading = pd.DataFrame(v, index=table.columns,
                                    columns=rename_cols)
     sample_loading = pd.DataFrame(u, index=table.index,
@@ -104,7 +105,7 @@ def rpca(table: biom.Table,
     dist_res = skbio.stats.distance.DistanceMatrix(
         opt.distance, ids=sample_loading.index)
 
-    return ord_res, dist_res
+    return ord_res, dist_res, robust_clr
 
 
 def auto_rpca(table: biom.Table,
@@ -117,10 +118,10 @@ def auto_rpca(table: biom.Table,
     """Runs RPCA but with auto estimation of the
        rank peramater.
     """
-    ord_res, dist_res = rpca(table,
-                             n_components='auto',
-                             min_sample_count=min_sample_count,
-                             min_feature_count=min_feature_count,
-                             min_feature_frequency=min_feature_frequency,
-                             max_iterations=max_iterations)
-    return ord_res, dist_res
+    ord_res, dist_res, robust_clr = rpca(
+        table, n_components='auto',
+        min_sample_count=min_sample_count,
+        min_feature_count=min_feature_count,
+        min_feature_frequency=min_feature_frequency,
+        max_iterations=max_iterations)
+    return ord_res, dist_res, robust_clr

--- a/deicode/scripts/_standalone_rpca.py
+++ b/deicode/scripts/_standalone_rpca.py
@@ -53,12 +53,12 @@ def rpca(in_biom: str,
     # import table
     table = load_table(in_biom)
     # run the RPCA wrapper
-    ord_res, dist_res = _rpca(table,
-                              n_components,
-                              min_sample_count,
-                              min_feature_count,
-                              min_feature_frequency,
-                              max_iterations)
+    ord_res, dist_res, robust_clr = _rpca(table,
+                                          n_components,
+                                          min_sample_count,
+                                          min_feature_count,
+                                          min_feature_frequency,
+                                          max_iterations)
 
     # If it doesn't already exist, create the output directory.
     # Note that there is technically a race condition here: it's ostensibly
@@ -75,6 +75,7 @@ def rpca(in_biom: str,
     # behavior if you specify --output-dir instead).
     ord_res.write(os.path.join(output_dir, 'ordination.txt'))
     dist_res.write(os.path.join(output_dir, 'distance-matrix.tsv'))
+    robust_clr.to_csv(os.path.join(output_dir, 'rclr.tsv'), '\t')
 
 
 @deicode.command('auto-rpca')
@@ -116,11 +117,11 @@ def auto_rpca(in_biom: str,
     # import table
     table = load_table(in_biom)
     # run the RPCA wrapper
-    ord_res, dist_res = _auto_rpca(table,
-                                   min_sample_count,
-                                   min_feature_count,
-                                   min_feature_frequency,
-                                   max_iterations)
+    ord_res, dist_res, robust_clr = _auto_rpca(table,
+                                               min_sample_count,
+                                               min_feature_count,
+                                               min_feature_frequency,
+                                               max_iterations)
 
     # If it doesn't already exist, create the output directory.
     # Note that there is technically a race condition here: it's ostensibly
@@ -137,6 +138,7 @@ def auto_rpca(in_biom: str,
     # behavior if you specify --output-dir instead).
     ord_res.write(os.path.join(output_dir, 'ordination.txt'))
     dist_res.write(os.path.join(output_dir, 'distance-matrix.tsv'))
+    robust_clr.to_csv(os.path.join(output_dir, 'rclr.tsv'), '\t')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Some users would benefit from being able to access the rclr transformed values, including myself.

I wrote this quick addition to return the rclr matrix and print it as tsv.

See issue #51 as an example.

I've been unhappy with the clr transforms implemented in R, but so far I'm happy with this one.

Thanks for putting the time to implement the matrix completion and rclr functions.